### PR TITLE
arrumando erro da atribuição dos ID's aos eventos

### DIFF
--- a/components/EventSection.vue
+++ b/components/EventSection.vue
@@ -4,7 +4,7 @@
     <div class="events">
       <div class="event" v-for="(event, index) in events" :key="event">
         <EventCard
-          :id="index"
+          :id="events.length - 1 - index"
           :eventName="event.name"
           :eventDescription="event.description"
           :eventDate="event.date"


### PR DESCRIPTION
Nessa PR, arrumo um erro relacionado á atribuição de ID's aos eventos.

Inverti a ordem os eventos em #31, mas não a inverti a atribuição dos ID's, que agora está funcionando corretamente.