### PR TITLE
Ignorar user-select enquanto interagir com a logo

### DIFF
--- a/src/lib/components/logo-3d/Logo3D.svelte
+++ b/src/lib/components/logo-3d/Logo3D.svelte
@@ -1,9 +1,20 @@
 <script>
 	import { Canvas } from '@threlte/core';
 	import Logo3DScene from './Logo3DScene.svelte';
+	import { browser } from '$app/environment';
+
+	const handleMouseEnter = () => {
+		if (!browser) return;
+		document.body.style.userSelect = 'none';
+	};
+
+	const handleMouseLeave = () => {
+		if (!browser) return;
+		document.body.style.userSelect = '';
+	};
 </script>
 
-<div class="logo-3d">
+<div class="logo-3d" on:mouseenter={handleMouseEnter} on:mouseleave={handleMouseLeave}>
 	<Canvas>
 		<Logo3DScene />
 	</Canvas>


### PR DESCRIPTION
**Problema:** ao interagir com a logo 3D e arrastar o mouse para cima de qualquer texto, o texto acaba sendo selecionado por consequência.

**Solução:** ignorar seleção de texto enquanto o mouse estiver interagindo com a logo.